### PR TITLE
Update chart to 1.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -21,6 +21,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 
 Once Helm has been set up correctly, add the repo as follows:
 
-```
-  helm repo add <alias> https://catalyst-cloud.github.io/capi-plugin-helm-charts
-```
+    helm repo add capi-plugin-helm-charts https://catalyst-cloud.github.io/capi-plugin-helm-charts
 
 If you had already added this repo earlier, run `helm repo update` to retrieve
-the latest versions of the packages.  You can then run `helm search repo
-<alias>` to see the charts.
+the latest versions of the packages.
 
-To install the <chart-name> chart:
+You can then run `helm search repo capi-plugin-helm-charts` to see the charts.
 
-    helm install my-<chart-name> <alias>/<chart-name>
+To install the k8s-keystone-auth chart:
+
+    helm install my-k8s-keystone-auth capi-plugin-helm-charts/k8s-keystone-auth
 
 To uninstall the chart:
 
-    helm delete my-<chart-name>
+    helm delete my-k8s-keystone-auth

--- a/charts/k8s-keystone-auth/Chart.yaml
+++ b/charts/k8s-keystone-auth/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
* Updates chart version to 1.5.1
* Updates github release actions to latest versions.
* Update index for helm chart page